### PR TITLE
Image with single histogram bucket causes invalid VBox->volume

### DIFF
--- a/lib/ColorThief/ColorThief.php
+++ b/lib/ColorThief/ColorThief.php
@@ -259,7 +259,7 @@ class ColorThief
     private static function vboxFromHistogram(array $histo)
     {
         $rgbMin = [PHP_INT_MAX, PHP_INT_MAX, PHP_INT_MAX];
-        $rgbMax = [0, 0, 0];
+        $rgbMax = [PHP_INT_MIN, PHP_INT_MIN, PHP_INT_MIN];
 
         // find min/max
         foreach ($histo as $index => $count) {
@@ -269,7 +269,8 @@ class ColorThief
             for ($i = 0; $i < 3; $i++) {
                 if ($rgb[$i] < $rgbMin[$i]) {
                     $rgbMin[$i] = $rgb[$i];
-                } elseif ($rgb[$i] > $rgbMax[$i]) {
+                }
+                if ($rgb[$i] > $rgbMax[$i]) {
                     $rgbMax[$i] = $rgb[$i];
                 }
             }

--- a/lib/ColorThief/ColorThief.php
+++ b/lib/ColorThief/ColorThief.php
@@ -259,7 +259,7 @@ class ColorThief
     private static function vboxFromHistogram(array $histo)
     {
         $rgbMin = [PHP_INT_MAX, PHP_INT_MAX, PHP_INT_MAX];
-        $rgbMax = [PHP_INT_MIN, PHP_INT_MIN, PHP_INT_MIN];
+        $rgbMax = [-PHP_INT_MAX, -PHP_INT_MAX, -PHP_INT_MAX];
 
         // find min/max
         foreach ($histo as $index => $count) {

--- a/tests/ColorThiefTest.php
+++ b/tests/ColorThiefTest.php
@@ -317,6 +317,28 @@ class ColorThiefTest extends \PHPUnit\Framework\TestCase
         $this->assertSame(26, $result->b2);
     }
 
+    /**
+     * Tests min and max RGB values are equal if there is only one color in the histogram.
+     */
+    public function testVboxFromSingleColorHistogram()
+    {
+        $method = new \ReflectionMethod('\ColorThief\ColorThief', 'vboxFromHistogram');
+        $method->setAccessible(true);
+
+        $histo = [
+            26756 => 120000,
+        ];
+
+        $result = $method->invoke(null, $histo);
+
+        $this->assertInstanceOf('\ColorThief\VBox', $result);
+        $this->assertSame($histo, $result->histo);
+        $this->assertSame($result->r1, $result->r2);
+        $this->assertSame($result->g1, $result->g2);
+        $this->assertSame($result->b1, $result->b2);
+        $this->assertSame(1, $result->volume());
+    }
+
     public function testDoCutLeftLetherThanRight()
     {
         $method = new \ReflectionMethod('\ColorThief\ColorThief', 'doCut');


### PR DESCRIPTION
An image that fits in a single histogram bucket (single color image) causes VBox->volume to be negative due to not setting rgbMax in addition to rgbMax.  This leave rgbMax at 0 causing VBox to compute a negative and incorrect volume as `$this->volume = (($this->r2 - $this->r1 + 1) * ($this->g2 - $this->g1 + 1) * ($this->b2 - $this->b1 + 1));`.